### PR TITLE
Fix link to lesson feed JSON

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,4 +6,4 @@ The data is stored in Airtable. The script is run on Travis daily through a CRON
 The data is provided at:
 
 - The list of curricula: <https://carpentries.github.io/curriculum-feed/carpentries_curricula.json>
-- The full list of our lessons: <https://carpentries.github.io/curriculum-feed/carpentries_lesson.json>
+- The full list of our lessons: <https://carpentries.github.io/curriculum-feed/carpentries_lessons.json>


### PR DESCRIPTION
Link to lesson feed JSON is missing an 's' at the end of "lesson".

https://carpentries.github.io/curriculum-feed/carpentries_lesson.json
should read
https://carpentries.github.io/curriculum-feed/carpentries_lessons.json